### PR TITLE
Instance enable disable

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
   branch = "master"
   name = "github.com/ghchinoy/ce-go"
   packages = ["ce"]
-  revision = "70faed00ff1b579a58489851757c82f5ff2057ff"
+  revision = "03676cecc9130eb9e8246e5d2b5550137773281f"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
   branch = "master"
   name = "github.com/ghchinoy/ce-go"
   packages = ["ce"]
-  revision = "53fdd2df7b1fcde9d5ea455ea82ef5b2eae300fa"
+  revision = "70faed00ff1b579a58489851757c82f5ff2057ff"
 
 [[projects]]
   branch = "master"
@@ -101,7 +101,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "dd2ff4accc098aceecb86b36eaa7829b2a17b1c9"
+  revision = "7dca6fe1f43775aa6d1334576870ff63f978f539"
 
 [[projects]]
   name = "golang.org/x/text"

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -434,6 +434,96 @@ If no object definitions exist, then this will result in an error response.`,
 	},
 }
 
+var instanceEnableCmd = &cobra.Command{
+	Use:   "enable <ID>",
+	Short: "Enable an Element Instance by ID",
+	Long:  "Enables an Element Instance, given an ID",
+	Run: func(cmd *cobra.Command, args []string) {
+		// check for profile
+		profilemap, err := getAuth(profile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		// check for Instance ID
+		if len(args) < 1 {
+			fmt.Println("Please provide an Instance ID ")
+			return
+		}
+		if _, err := strconv.ParseInt(args[0], 10, 64); err != nil {
+			fmt.Println("Please provide an Instance ID that is an integer")
+			return
+		}
+		// Get schema definition for operation
+		bodybytes, statuscode, curlcmd, err := ce.EnableElementInstance(profilemap["base"], profilemap["auth"], args[0], true, debug)
+		if err != nil {
+			if statuscode == -1 {
+				fmt.Println("Unable to reach CE API. Please check your configuration / profile.")
+			}
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		// handle global options, curl
+		if showCurl {
+			log.Println(curlcmd)
+		}
+		// handle non 200
+		if statuscode != 200 {
+			log.Printf("HTTP Error: %v\n", statuscode)
+			// handle this nicely, show error description
+			fmt.Printf("%s\n", bodybytes)
+		}
+		if statuscode == 200 {
+			fmt.Println("Instance enabled.")
+		}
+	},
+}
+
+var instanceDisableCmd = &cobra.Command{
+	Use:   "disable <ID>",
+	Short: "Disable an Element Instance by ID",
+	Long:  "Disables an Element Instance, given an ID",
+	Run: func(cmd *cobra.Command, args []string) {
+		// check for profile
+		profilemap, err := getAuth(profile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		// check for Instance ID
+		if len(args) < 1 {
+			fmt.Println("Please provide an Instance ID ")
+			return
+		}
+		if _, err := strconv.ParseInt(args[0], 10, 64); err != nil {
+			fmt.Println("Please provide an Instance ID that is an integer")
+			return
+		}
+		// Get schema definition for operation
+		bodybytes, statuscode, curlcmd, err := ce.EnableElementInstance(profilemap["base"], profilemap["auth"], args[0], false, debug)
+		if err != nil {
+			if statuscode == -1 {
+				fmt.Println("Unable to reach CE API. Please check your configuration / profile.")
+			}
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		// handle global options, curl
+		if showCurl {
+			log.Println(curlcmd)
+		}
+		// handle non 200
+		if statuscode != 200 {
+			log.Printf("HTTP Error: %v\n", statuscode)
+			// handle this nicely, show error description
+			fmt.Printf("%s\n", bodybytes)
+		}
+		if statuscode == 200 {
+			fmt.Println("Instance disabled.")
+		}
+	},
+}
+
 var instanceOperationDefinitionCmd = &cobra.Command{
 	Use:   "operation [ID] [operationName]",
 	Short: "Show operation schema definition",
@@ -506,8 +596,11 @@ func init() {
 	instancesCmd.AddCommand(instanceDefinitionsCmd)
 	instancesCmd.AddCommand(testInstancesCmd)
 	instancesCmd.AddCommand(deleteElementInstanceCmd)
+	instancesCmd.AddCommand(instanceEnableCmd)
+	instancesCmd.AddCommand(instanceDisableCmd)
 
 	instancesCmd.PersistentFlags().StringVar(&profile, "profile", "default", "profile name")
 	instancesCmd.PersistentFlags().BoolVarP(&outputJSON, "json", "j", false, "output as json")
 	instancesCmd.PersistentFlags().BoolVarP(&showCurl, "curl", "c", false, "show curl command")
+	instancesCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "print debug info")
 }

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -434,6 +434,66 @@ If no object definitions exist, then this will result in an error response.`,
 	},
 }
 
+var instanceEventsEnableCmd = &cobra.Command{
+	Use:   "events-enable <ID> [true|false]",
+	Short: "Enable or disable events on an Element Instance",
+	Long: `A dual-use command that allows enabling or disabling events on an 
+Element Instance, given an Instance ID and a boolean for
+enabling or disabling Events`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// check for profile
+		profilemap, err := getAuth(profile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		// check for Instance ID
+		if len(args) < 1 {
+			fmt.Println("Please provide an Instance ID ")
+			return
+		}
+		if _, err := strconv.ParseInt(args[0], 10, 64); err != nil {
+			fmt.Println("Please provide an Instance ID that is an integer")
+			return
+		}
+		enable := true
+		if len(args) == 2 {
+			if _, err := strconv.ParseBool(args[1]); err != nil {
+				fmt.Println("Please provide an enable boolean that's either true | false")
+				return
+			}
+			enable, _ = strconv.ParseBool(args[1])
+		}
+		bodybytes, statuscode, curlcmd, err := ce.EnableElementInstanceEvents(profilemap["base"], profilemap["auth"], args[0], enable, debug)
+		if err != nil {
+			if statuscode == -1 {
+				fmt.Println("Unable to reach CE API. Please check your configuration / profile.")
+			}
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		// handle global options, curl
+		if showCurl {
+			log.Println(curlcmd)
+		}
+		// handle non 200
+		if statuscode != 200 {
+			log.Printf("HTTP Error: %v\n", statuscode)
+			// handle this nicely, show error description
+			fmt.Printf("%s\n", bodybytes)
+		}
+		var instance ce.ElementInstance
+		err = json.Unmarshal(bodybytes, &instance)
+		if err != nil {
+			fmt.Println("Unable to unmarshal Element Instance")
+			os.Exit(1)
+		}
+		if statuscode == 200 {
+			fmt.Printf("Instance %s/%s events: %v.\n", instance.Element.Key, instance.Name, instance.Configuration.EventNotificationEnabled)
+		}
+	},
+}
+
 var instanceEnableCmd = &cobra.Command{
 	Use:   "enable <ID>",
 	Short: "Enable an Element Instance by ID",
@@ -454,7 +514,7 @@ var instanceEnableCmd = &cobra.Command{
 			fmt.Println("Please provide an Instance ID that is an integer")
 			return
 		}
-		// Get schema definition for operation
+		// Enable Element Instance
 		bodybytes, statuscode, curlcmd, err := ce.EnableElementInstance(profilemap["base"], profilemap["auth"], args[0], true, debug)
 		if err != nil {
 			if statuscode == -1 {
@@ -473,8 +533,18 @@ var instanceEnableCmd = &cobra.Command{
 			// handle this nicely, show error description
 			fmt.Printf("%s\n", bodybytes)
 		}
+		var instance ce.ElementInstance
+		err = json.Unmarshal(bodybytes, &instance)
+		if err != nil {
+			fmt.Println("Unable to unmarshal Element Instance")
+			os.Exit(1)
+		}
 		if statuscode == 200 {
-			fmt.Println("Instance enabled.")
+			state := "enabled"
+			if instance.Disabled {
+				state = "disabled"
+			}
+			fmt.Printf("Instance %s/%s %s.\n", instance.Element.Key, instance.Name, state)
 		}
 	},
 }
@@ -518,8 +588,18 @@ var instanceDisableCmd = &cobra.Command{
 			// handle this nicely, show error description
 			fmt.Printf("%s\n", bodybytes)
 		}
+		var instance ce.ElementInstance
+		err = json.Unmarshal(bodybytes, &instance)
+		if err != nil {
+			fmt.Println("Unable to unmarshal Element Instance")
+			os.Exit(1)
+		}
 		if statuscode == 200 {
-			fmt.Println("Instance disabled.")
+			state := "enabled"
+			if instance.Disabled {
+				state = "disabled"
+			}
+			fmt.Printf("Instance %s/%s %s.\n", instance.Element.Key, instance.Name, state)
 		}
 	},
 }
@@ -598,6 +678,7 @@ func init() {
 	instancesCmd.AddCommand(deleteElementInstanceCmd)
 	instancesCmd.AddCommand(instanceEnableCmd)
 	instancesCmd.AddCommand(instanceDisableCmd)
+	instancesCmd.AddCommand(instanceEventsEnableCmd)
 
 	instancesCmd.PersistentFlags().StringVar(&profile, "profile", "default", "profile name")
 	instancesCmd.PersistentFlags().BoolVarP(&outputJSON, "json", "j", false, "output as json")

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -489,7 +489,8 @@ enabling or disabling Events`,
 			os.Exit(1)
 		}
 		if statuscode == 200 {
-			fmt.Printf("Instance %s/%s events: %v.\n", instance.Element.Key, instance.Name, instance.Configuration.EventNotificationEnabled)
+			ce.OutputInstanceDetails(bodybytes)
+			//fmt.Printf("Instance %s/%s events: %v.\n", instance.Element.Key, instance.Name, instance.Configuration.EventNotificationEnabled)
 		}
 	},
 }


### PR DESCRIPTION
Adds three commands
* `instances enable <instance_id>` - to enable an Element Instance
* `instances disable <instance_id>` - to disable an Element Instance
* `instances events-enable <instance_id> [true|false]` - a single command that enables or disables an Element Instances events, given a true|false (bool) option