### PR TITLE
v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ BUG FIXES:
 
 IMPROVEMENTS:
 
+# v0.12.0
+
+NEW FEATURES:
+
+BUG FIXES:
+
+* Listing of Formual Instance Executions now enforces requiring of an ID (`executions list <id>`) ([#40](https://github.com/ghchinoy/cectl/issues/40))
+
+IMPROVEMENTS:
+
+* Output of `formula-instances create` now shows created Formula Instance ID ([#36](https://github.com/ghchinoy/cectl/issues/36), [#10](https://github.com/ghchinoy/cectl/issues/10))
+
 # v0.11.0
 
 NEW FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ IMPROVEMENTS:
 
 NEW FEATURES:
 
+* Initial release of CE UI Branding management via `branding` command - implemented `get` and `reset`, with `set` available, but hidden, as there's more work to do ([#10](https://github.com/ghchinoy/cectl/issues/10))
+
 BUG FIXES:
 
 * Listing of Formual Instance Executions now enforces requiring of an ID (`executions list <id>`) ([#40](https://github.com/ghchinoy/cectl/issues/40))

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
   branch = "master"
   name = "github.com/ghchinoy/ce-go"
   packages = ["ce"]
-  revision = "2b08df7a1508a24ac8658bf1f16aa93323844cbb"
+  revision = "83005e3e2ce6c8684119db45affcbbc610e616b3"
 
 [[projects]]
   branch = "master"
@@ -65,7 +65,7 @@
   branch = "master"
   name = "github.com/spf13/afero"
   packages = [".","mem"]
-  revision = "bbf41cb36dffe15dff5bf7e18c447801e7ffe163"
+  revision = "a880a37ed1804d98f64b3b7d58b5e3f8fbf421c4"
 
 [[projects]]
   name = "github.com/spf13/cast"
@@ -101,7 +101,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "1e3c7779a71dac3e6f1a2abb347a6734b72d35e7"
+  revision = "91ee8cde435411ca3f1cd365e8f20131aed4d0a1"
 
 [[projects]]
   name = "golang.org/x/text"

--- a/makedist
+++ b/makedist
@@ -5,7 +5,7 @@
 # No need to change anything below ####
 # 
 
-VERSION=0.11.0
+VERSION=0.12.0
 
 TOOLNAME=cectl
 OSLIST=(linux darwin windows)

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	version     = "0.11.0"
+	version     = "0.12.0"
 	versionName = "stratocumulus"
 )
 


### PR DESCRIPTION
# v0.12.0

NEW FEATURES:

* Initial release of CE UI Branding management via `branding` command - implemented `get` and `reset`, with `set` available, but hidden, as there's more work to do ([#10](https://github.com/ghchinoy/cectl/issues/10))

BUG FIXES:

* Listing of Formual Instance Executions now enforces requiring of an ID (`executions list <id>`) ([#40](https://github.com/ghchinoy/cectl/issues/40))

IMPROVEMENTS:

* Output of `formula-instances create` now shows created Formula Instance ID ([#36](https://github.com/ghchinoy/cectl/issues/36), [#10](https://github.com/ghchinoy/cectl/issues/10))
