### PR TITLE
Export transformation correction

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -102,8 +102,8 @@
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/spf13/viper"
@@ -115,7 +115,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "3b87a42e500a6dc65dae1a55d0b641295971163e"
+  revision = "f6f352972f061230a99fbf49d1eb8073ebdb36cb"
 
 [[projects]]
   name = "golang.org/x/text"

--- a/cmd/molecules.go
+++ b/cmd/molecules.go
@@ -265,7 +265,7 @@ func ExportAllTransformationsToDir(base, auth string, dirname string) error {
 
 	log.Println("Exporting Transformations per Element")
 	for _, v := range elementkeys {
-		transforms := make(map[string]ce.Transformation)
+		transforms := make(map[string][]byte)
 		bodybytes, status, _, err := ce.GetTransformationsPerElement(base, auth, v)
 		if err != nil {
 			break
@@ -273,17 +273,18 @@ func ExportAllTransformationsToDir(base, auth string, dirname string) error {
 		if status != 200 {
 			break
 		}
+
 		err = json.Unmarshal(bodybytes, &transforms)
+		if err != nil {
+			log.Println("unable to umarshal Transformation JSON")
+			break
+		}
 
 		for n, t := range transforms {
 			filename := fmt.Sprintf("%s_%s.transformation.json", v, n)
-			data, err := json.Marshal(t)
-			if err != nil {
-				log.Println("Error creating []byte from ce.Transform object")
-				break
-			}
+
 			log.Printf("Exporting %s", filename)
-			err = ioutil.WriteFile(fmt.Sprintf("%s/%s", dirname, filename), data, 0644)
+			err = ioutil.WriteFile(fmt.Sprintf("%s/%s", dirname, filename), t, 0644)
 			if err != nil {
 				log.Println("Error writing file")
 				break

--- a/cmd/molecules.go
+++ b/cmd/molecules.go
@@ -159,7 +159,7 @@ func CombineVirtualDataResourcesForExport(base, auth string) (AllVDR, error) {
 	vdr.ObjectDefinitions = objs
 
 	// Gather Transformations
-	txs := make(map[string]map[string]ce.Transformation)
+	txs := make(map[string]map[string]interface{})
 	// Get all available transformations
 	log.Println("Getting all available Transformations")
 	bodybytes, status, _, err := ce.GetTransformations(base, auth)
@@ -197,7 +197,7 @@ func CombineVirtualDataResourcesForExport(base, auth string) (AllVDR, error) {
 		}
 	}
 	for _, v := range elementkeys {
-		transforms := make(map[string]ce.Transformation)
+		transforms := make(map[string]interface{})
 		bodybytes, status, _, err := ce.GetTransformationsPerElement(base, auth, v)
 		if err != nil {
 			break


### PR DESCRIPTION
Related to #26 , transformation exports in `molecules export` and `molecule exports --combined` output raw JSON to accommodate for transformation configuration[]{.properties} which may be empty as per [golang #11939](https://github.com/golang/go/issues/11939)