### PR TITLE
Adds ability to login to create profile

### DIFF
--- a/tokens/inquire.go
+++ b/tokens/inquire.go
@@ -1,0 +1,108 @@
+package tokens
+
+import (
+	"github.com/AlecAivazis/survey"
+)
+
+var usernameQuestion = survey.Question{
+	Name:     "un",
+	Prompt:   &survey.Input{Message: "Username"},
+	Validate: survey.Required,
+}
+
+var passwordQuestion = survey.Question{
+	Name:     "pwd",
+	Prompt:   &survey.Password{Message: "Password"},
+	Validate: survey.Required,
+}
+var environmentQuestion = survey.Question{
+	Name: "env",
+	Prompt: &survey.Select{
+		Message: "Choose an environment:",
+		Options: []string{"snapshot", "staging", "production", "uk"},
+		Default: "snapshot",
+	},
+	Transform: environmentTransformer,
+}
+var outputQuestion = survey.Question{
+	Name: "output",
+	Prompt: &survey.Select{
+		Message: "Choose an output method:",
+		Options: []string{"toml", "json"},
+		Default: "toml",
+	},
+}
+
+// not used
+var prompts = []*survey.Question{
+	&usernameQuestion,
+	&passwordQuestion,
+	&environmentQuestion,
+	&outputQuestion,
+}
+
+var u, p, e, o string
+
+var environments map[string]string
+
+func init() {
+	environments = make(map[string]string)
+	environments["snapshot"] = "https://snapshot.cloud-elements.com/elements/api-v2"
+	environments["staging"] = "https://staging.cloud-elements.com/elements/api-v2"
+	environments["production"] = "https://api.cloud-elements.com/elements/api-v2"
+	environments["uk"] = "https://console.cloud-elements.co.uk/elements/api-v2"
+
+}
+
+func LoginInquiry() (string, string, string, error) {
+
+	var org, user string
+	var config Config
+
+	survey.Ask([]*survey.Question{&usernameQuestion}, &config)
+	survey.Ask([]*survey.Question{&passwordQuestion}, &config)
+	survey.Ask([]*survey.Question{&environmentQuestion}, &config)
+	config.Output = "toml"
+
+	token, err := ObtainCEToken(config)
+	if err != nil {
+		return config.Environment, org, user, err
+	}
+
+	return config.Environment, token.Organization, token.User, nil
+
+}
+
+// environmentTransformer is used by the AlecAivazis.survey package
+// to look up the Cloud Elements endpoint base URL from a string input
+func environmentTransformer(answer interface{}) interface{} {
+	s, ok := answer.(string)
+	if !ok {
+		return nil
+	}
+	return environments[s]
+}
+
+/*
+// askFor prompts for user input, optionally a password field
+func askFor(prompt string, isPassword bool) (string, error) {
+	var result string
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("%s ", prompt)
+	if isPassword {
+		pwdBytes, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return result, err
+		}
+		result = string(pwdBytes)
+		fmt.Println()
+	} else {
+		var err error
+		result, err = reader.ReadString('\n')
+		if err != nil {
+			return result, err
+		}
+	}
+	return strings.TrimSpace(result), nil
+}
+*/

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -1,0 +1,139 @@
+package tokens
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// Config holds the CE configuration info
+type Config struct {
+	Username    string `survey:"un"`
+	Environment string `survey:"env"`
+	Password    string `survey:"pwd"`
+	Output      string
+}
+
+// Token is a temp structure for a Cloud Elements token
+type Token struct {
+	User         string `json:"userSecret"`
+	Organization string `json:"organizationSecret"`
+}
+
+// ObtainCEToken returns a Token struct given a Config struct
+func ObtainCEToken(config Config) (Token, error) {
+	var token Token
+
+	// POST to /authentication
+	payload := struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}{
+		config.Username,
+		config.Password,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	url := fmt.Sprintf("%s/%s", config.Environment, "authentication")
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payloadBytes))
+	if err != nil {
+		return token, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return token, err
+	}
+	defer res.Body.Close()
+	bodybytes, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return token, err
+	}
+
+	var response map[string]interface{}
+	err = json.Unmarshal(bodybytes, &response)
+	if err != nil {
+		return token, err
+	}
+	if _, ok := response["token"]; !ok {
+		return token, fmt.Errorf("empty token received for %s @ %s", config.Username, url)
+	}
+
+	// GET /authentication/secrets
+	url = fmt.Sprintf("%s/%s", config.Environment, "/authentication/secrets")
+	req, err = http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return token, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", response["token"].(string)))
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return token, err
+	}
+	defer res.Body.Close()
+	bodybytes, err = ioutil.ReadAll(res.Body)
+	if err != nil {
+		return token, err
+	}
+
+	err = json.Unmarshal(bodybytes, &token)
+	if err != nil {
+		return token, err
+	}
+
+	return token, nil
+}
+
+// OutputCectlTOML outputs TOML
+func OutputCectlTOML(config Config, token Token) {
+	fmt.Printf("[%s]\n", strings.Replace(
+		strings.Split(config.Username, "@")[0],
+		"+",
+		"_",
+		-1,
+	),
+	)
+	fmt.Printf("  base = \"%s\"\n", config.Environment)
+	fmt.Printf("  org =\"%s\"\n", token.Organization)
+	fmt.Printf("  user = \"%s\"\n", token.User)
+}
+
+// PostmanEnvironment is a structure for a Postman Environment json config
+type PostmanEnvironment struct {
+	Name   string                    `json:"name"`
+	Values []PostmanEnvironmentValue `json:"values"`
+}
+
+// PostmanEnvironmentValue is a value for a Postman Environment json config
+type PostmanEnvironmentValue struct {
+	Enabled bool   `json:"enabled"`
+	Key     string `json:"key"`
+	Value   string `json:"value"`
+	Type    string `json:"type"`
+}
+
+// OutputPostmanEnvJSON outputs JSON for a Postman Environment file
+func OutputPostmanEnvJSON(config Config, token Token) error {
+	envjson := PostmanEnvironment{
+		Name: config.Username,
+		Values: []PostmanEnvironmentValue{
+			{Enabled: true, Type: "text", Key: "PlatformBaseURI", Value: config.Environment},
+			{Enabled: true, Type: "text", Key: "OrganizationID", Value: token.Organization},
+			{Enabled: true, Type: "text", Key: "AdminUserID", Value: token.User},
+		},
+	}
+
+	outputbytes, err := json.MarshalIndent(envjson, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s\n", outputbytes)
+
+	return nil
+}


### PR DESCRIPTION
Improves ease of use for adding in new profiles.
New flag added to `profiles add <profile_name>` to obtain cectl configuration profile from login to CE environment.
Using flag `-l` or `--login`, username, password, and environment choice prompts provided and new configuration profile "profile_name" added to default cectl.toml file.