### PR TITLE
v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,6 @@ BUG FIXES:
 
 IMPROVEMENTS:
 
-# v0.15.3
-
-NEW FEATURES:
-
-BUG FIXES:
-
-IMPROVEMENTS:
-
-* Updates to latest ce-go client which shows user privileges with roles  in JSON output via `user list -r --json`
-
-
 # v0.16.0
 
 NEW FEATURES:
@@ -26,7 +15,19 @@ NEW FEATURES:
 
 BUG FIXES:
 
+* `profiles list -l` now lists all profiles rather than a truncated list
+
 IMPROVEMENTS:
+
+# v0.15.3
+
+NEW FEATURES:
+
+BUG FIXES:
+
+IMPROVEMENTS:
+
+* Updates to latest ce-go client which shows user privileges with roles  in JSON output via `user list -r --json`
 
 # v0.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ IMPROVEMENTS:
 * Updates to latest ce-go client which shows user privileges with roles  in JSON output via `user list -r --json`
 
 
+# v0.16.0
+
+NEW FEATURES:
+
+* `profiles init` creates a new, blank cectl.toml config file if the file doesn't exist, in the default location
+* `profiles add -l` or `profiles add --login` begins an interactive login session to create a cectl.toml file
+
+BUG FIXES:
+
+IMPROVEMENTS:
+
 # v0.15.2
 
 NEW FEATURES:

--- a/makedist
+++ b/makedist
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Go cross-compile 
+# Go cross-compile
 # Usually, only the VERSION changes.
 # The OSLIST and ARCHLIST can change, as well.
 # No need to change anything below ####
-# 
+#
 
-VERSION=0.15.3
+VERSION=0.16.0
 
 TOOLNAME=cectl
 OSLIST=(linux darwin windows)

--- a/version.go
+++ b/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	version     = "0.15.3"
+	version     = "0.16.0"
 	versionName = "stratocumulus"
 )
 


### PR DESCRIPTION
NEW FEATURES:

* `profiles init` creates a new, blank cectl.toml config file if the file doesn't exist, in the default location
* `profiles add -l` or `profiles add --login` begins an interactive login session to create a cectl.toml file

BUG FIXES:

* `profiles list -l` now lists all profiles rather than a truncated list